### PR TITLE
Change to a working link for Ruby Rack

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ pre.code { background: #222; color: #ddd; font-size: 1.2em; padding: 1em }
 
 <p>PSGI is an <strong>interface</strong> between Perl web applications and web servers, and Plack is a Perl module and <strong>toolkit</strong> that contains PSGI middleware, helpers and adapters to web servers.</p>
 
-<p>PSGI and Plack are inspired by Python's <a href="http://www.python.org/dev/peps/pep-0333/">WSGI</a> and Ruby's <a href="http://rack.rubyforge.org/">Rack</a>.</p>
+<p>PSGI and Plack are inspired by Python's <a href="http://www.python.org/dev/peps/pep-0333/">WSGI</a> and Ruby's <a href="https://github.com/rack/rack">Rack</a>.</p>
 
 <h2 id="documentation">Documentation</h2>
 


### PR DESCRIPTION
When viewing plackperl.org, I noticed that the link to Ruby Rack was broken. Here I've changed the link to Rack's active GitHub repo.